### PR TITLE
Pygrun fix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
                do
                 cat $f
                 echo "AST> "
-                pygrun parse calc.g4 prog $f
+                antlr4-parse calc.g4 prog -tree $f
                 echo "---------------------"
               done
       - name: Run user code

--- a/calc.g4
+++ b/calc.g4
@@ -1,13 +1,11 @@
 grammar calc;
 
 prog : (expr NEWLINE)* ;
-expr : '(' content ')'
-     | content
+expr : INT OP INT
+     | num
+     | '(' expr ')'
      ;
-content : INT
-     | INT OP INT;
+num  : INT ;
 NEWLINE : [\r\n]+;
 INT  : [0-9]+ ;
 OP   : ( '+' | '-' | '*' | '/' ) ;
-fragment OPEN : '(';
-fragment CLOSE: ')';

--- a/calc.g4
+++ b/calc.g4
@@ -5,6 +5,7 @@ expr : INT OP INT
      | num
      | '(' expr ')'
      ;
+     
 num  : INT ;
 NEWLINE : [\r\n]+;
 INT  : [0-9]+ ;

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 antlr4-grun==0.4.1
 antlr4-python3-runtime==4.8
+antlr4-tools==0.1


### PR DESCRIPTION
Reconfigured project to use antlr4-tools directly instead of using pygrun. This was done by adding antlr4-tools to the requirements.txt file and replacing the run command in the main.yml file. 

Requirement:
`antlr4-tools==0.1`

New command:
`antlr4-parse calc.g4 prog -tree $f`